### PR TITLE
Remove "#comment-block" pattern from strings

### DIFF
--- a/CSS3.tmLanguage
+++ b/CSS3.tmLanguage
@@ -10706,6 +10706,15 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.double.css</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\([\da-fA-F]{4}|.)</string>
+					<key>name</key>
+					<string>constant.character.escape.css</string>
+				</dict>
+			</array>
 		</dict>
 		<key>type-string-single</key>
 		<dict>
@@ -10731,6 +10740,15 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.single.css</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\([\da-fA-F]{4}|.)</string>
+					<key>name</key>
+					<string>constant.character.escape.css</string>
+				</dict>
+			</array>
 		</dict>
 		<key>type-time</key>
 		<dict>

--- a/CSS3.tmLanguage
+++ b/CSS3.tmLanguage
@@ -10706,13 +10706,6 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.double.css</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#comment-block</string>
-				</dict>
-			</array>
 		</dict>
 		<key>type-string-single</key>
 		<dict>
@@ -10738,13 +10731,6 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.single.css</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#comment-block</string>
-				</dict>
-			</array>
 		</dict>
 		<key>type-time</key>
 		<dict>


### PR DESCRIPTION
Comments shouldn't be matched inside of strings. It [seems](https://developer.mozilla.org/en-US/docs/Web/CSS/string) like they can contain anything except line breaks.

I also added escapes. I wan't sure what to scope them as, so I went with what I call them in [babel-sublime](https://github.com/babel/babel-sublime/blob/52b1a26a21e717eacbcd96048e8289b08ac2a0d5/JavaScript%20(Babel).YAML-tmLanguage#L1025-L1026).

![before](https://cloud.githubusercontent.com/assets/830952/7558229/a71cba18-f76d-11e4-80d7-1942acb36d7d.png)

![after](https://cloud.githubusercontent.com/assets/830952/7558230/a9658c00-f76d-11e4-94dd-df436cdc513b.png)