### PR TITLE
 Whitespace Fix for Comments initiated with Ctrl+/ . Comments previou…

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -14,13 +14,13 @@
 				<key>name</key>
 				<string>TM_COMMENT_START</string>
 				<key>value</key>
-				<string>/*</string>
+				<string>/* </string>
 			</dict>
 			<dict>
 				<key>name</key>
 				<string>TM_COMMENT_END</string>
 				<key>value</key>
-				<string>*/</string>
+				<string> */</string>
 			</dict>
 			<dict>
 				<key>name</key>


### PR DESCRIPTION
Whitespace Fix for Comments initiated with `Ctrl+/` . Comments previously displayed as `/*Comment Here*/` and now display as `/* Comment Here */`

In **Comments.tmPreferences**:
17: now reads `<string>/* </string>`
23: now reads `<string> */</string>`

See Issue https://github.com/y0ssar1an/CSS3/issues/53