### PR TITLE
HTML 5.2 updates and WHATWG Fullscreen API

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -10170,8 +10170,11 @@ contexts:
           nobr|
           nextid|
           multicol|
+          menuitem|
+          menu|
           marquee|
           listing|
+          keygen|
           isindex|
           hgroup|
           frameset|

--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -9858,6 +9858,7 @@ contexts:
           hover|
           host|
           future|
+          fullscreen|
           focus|
           focus-within|
           first-of-type|
@@ -10053,6 +10054,7 @@ contexts:
           first-letter|
           content|
           before|
+          backdrop|
           after|
           -webkit-input-placeholder|
           -ms-input-placeholder|

--- a/completions/selectors.py
+++ b/completions/selectors.py
@@ -70,8 +70,6 @@ html_tags = [
     ("main",),
     ("map",),
     ("mark",),
-    ("menu",),
-    ("menuitem",),
     ("meta",),
     ("meter",),
     ("nav",),

--- a/completions/selectors.py
+++ b/completions/selectors.py
@@ -145,6 +145,7 @@ pseudo_classes = [
     ("first-of-type",),
     ("focus",),
     ("focus-within",),
+    ("fullscreen",),
     ("future",),
     ("has()", "has(${1})"),
     ("host",),
@@ -189,6 +190,7 @@ pseudo_classes = [
 pseudo_elements = [
     ("after",),
     ("attr()", "attr(${1})"),
+    ("backdrop",),
     ("before",),
     ("content",),
     ("first-letter",),


### PR DESCRIPTION
* flag `keygen`, `menu`, and `menuitem` selectors as deprecated
  * [deprecated in HTML 5.2](https://www.w3.org/TR/2017/REC-html52-20171214/changes.html#features-removed)
* remove `menu` and `menuitem` completions
* add `:fullscreen` pseudo-class and `::backdrop` pseudo-element from [the WHATWG Fullscreen spec](https://fullscreen.spec.whatwg.org/)