### PR TITLE
Add support for subgrids from Grid Layout Module Level 2

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -1390,6 +1390,7 @@ contexts:
         \b
         (?:
           table|
+          subgrid|
           ruby|
           grid|
           flow-root|
@@ -3594,6 +3595,7 @@ contexts:
         - include: content-distribution
         - include: overflow-position
         - include: content-position
+        - include: number
     - include: stray-paren-or-semicolon
 
   # align-items is defined in two specs:
@@ -6230,7 +6232,7 @@ contexts:
         - include: end-value
         - include: value-css-wide
         - include: string
-        - match: '\b(?:none|dense|auto-flow){{b}}'
+        - match: '\b(?:subgrid|none|dense|auto-flow){{b}}'
           scope: support.constant.property-value.css
         - include: track-list
         - include: auto-track-list
@@ -6303,7 +6305,7 @@ contexts:
         - include: end-value
         - include: value-css-wide
         - include: string
-        - match: '\bnone{{b}}'
+        - match: '\b(?:subgrid|none){{b}}'
           scope: support.constant.property-value.css
         - include: track-size
         - include: line-names
@@ -6339,7 +6341,7 @@ contexts:
         - meta_content_scope: meta.property-value.grid-template-rows-columns.css
         - include: end-value
         - include: value-css-wide
-        - match: '\bnone{{b}}'
+        - match: '\b(?:subgrid|none){{b}}'
           scope: support.constant.property-value.css
         - include: track-list
         - include: auto-track-list
@@ -6599,6 +6601,7 @@ contexts:
         - include: content-distribution
         - include: overflow-position
         - include: content-position
+        - include: number
     - include: stray-paren-or-semicolon
 
   # CSS Box Alignment Module Level 3

--- a/completions/properties.py
+++ b/completions/properties.py
@@ -541,7 +541,7 @@ media_features = [
 name_to_completions = {
     "align-content": [
         ("normal",),
-    ] + t.baseline_position + t.content_distribution + t.content_position + t.overflow_position,
+    ] + t.baseline_position + t.content_distribution + t.content_position + t.overflow_position + t.number,
     "align-items": [
         ("normal",),
         ("stretch",),
@@ -1021,6 +1021,7 @@ name_to_completions = {
         ("auto-flow",),
         ("dense",),
         ("none",),
+        ("subgrid",),
         t.string,
     ] + t.auto_track_list + t.track_list,
     "grid-row-column-area": t.grid_line,
@@ -1028,9 +1029,13 @@ name_to_completions = {
     "grid-auto-flow": [("column",), ("dense",), ("row",)],
     "grid-auto-rows-columns": t.track_size,
     "grid-template-areas": [("none",), t.string],
-    "grid-template-rows-columns": [("none",)] + t.auto_track_list + t.track_list,
+    "grid-template-rows-columns": [
+        ("none",),
+        ("subgrid",),
+    ] + t.auto_track_list + t.track_list,
     "grid-template": [
         ("none",),
+        ("subgrid",),
         t.line_names,
         t.string,
     ] + t.fixed_size + t.track_size,
@@ -1096,7 +1101,8 @@ name_to_completions = {
     ] + (
         t.content_distribution +
         t.overflow_position +
-        t.content_position
+        t.content_position +
+        t.number
     ),
     "justify-items": [
         ("center",),

--- a/completions/types.py
+++ b/completions/types.py
@@ -402,6 +402,7 @@ display_inside = [
     ("flow-root",),
     ("grid",),
     ("ruby",),
+    ("subgrid",),
     ("table",),
 ]
 display_internal = [


### PR DESCRIPTION
### examples of new subgrid values in [Grid Layout Module Level 2](https://drafts.csswg.org/css-grid-2/)
```
display: subgrid
grid: subgrid
align-content: 1
justify-content: 1
grid-template-rows: subgrid
```