### PR TITLE
Add new properties from Text Decoration Module Level 4

### DIFF
--- a/CSS3.sublime-syntax
+++ b/CSS3.sublime-syntax
@@ -3466,10 +3466,13 @@ contexts:
     - include: property-text-decoration-color
     - include: property-text-decoration-line
     - include: property-text-decoration-skip
+    - include: property-text-decoration-skip-ink
     - include: property-text-decoration-style
+    - include: property-text-decoration-width
     - include: property-text-emphasis
     - include: property-text-emphasis-color
     - include: property-text-emphasis-position
+    - include: property-text-emphasis-skip
     - include: property-text-emphasis-style
     - include: property-text-indent
     - include: property-text-justify
@@ -3482,6 +3485,7 @@ contexts:
     - include: property-text-space-trim
     - include: property-text-spacing
     - include: property-text-transform
+    - include: property-text-underline-offset
     - include: property-text-underline-position
     - include: property-text-wrap
     - include: property-transform-box
@@ -5129,7 +5133,6 @@ contexts:
           text-kashida-space|
           text-justify-trim|
           text-first-indent|
-          text-emphasis-skip|
           text-combine-mode|
           text-combine-horizontal|
           text-combine|
@@ -8781,7 +8784,7 @@ contexts:
           scope: support.constant.property-value.css
     - include: stray-paren-or-semicolon
 
-  # CSS Text Decoration Module Level 3
+  # CSS Text Decoration Module Level 4
   property-text-decoration-skip:
     - match: \b(text-decoration-skip)\s*(:)
       captures:
@@ -8794,14 +8797,29 @@ contexts:
         - match: '(?x)
             \b
             (?:
+              trailing-spaces|
               spaces|
               objects|
               none|
-              ink|
+              leading-spaces|
               edges|
               box-decoration
             )
             {{b}}'
+          scope: support.constant.property-value.css
+    - include: stray-paren-or-semicolon
+
+  # CSS Text Decoration Module Level 4
+  property-text-decoration-skip-ink:
+    - match: \b(text-decoration-skip-ink)\s*(:)
+      captures:
+        1: support.constant.property-name.css
+        2: punctuation.separator.key-value.css
+      push:
+        - meta_content_scope: meta.property-value.text-decoration-skip-ink.css
+        - include: end-value
+        - include: value-css-wide
+        - match: '\b(?:none|auto){{b}}'
           scope: support.constant.property-value.css
     - include: stray-paren-or-semicolon
 
@@ -8874,6 +8892,20 @@ contexts:
           scope: support.constant.property-value.css
     - include: stray-paren-or-semicolon
 
+  # CSS Text Decoration Module Level 4
+  property-text-emphasis-skip:
+    - match: \b(text-emphasis-skip)\s*(:)
+      captures:
+        1: support.constant.property-name.css
+        2: punctuation.separator.key-value.css
+      push:
+        - meta_content_scope: meta.property-value.text-emphasis-skip.css
+        - include: end-value
+        - include: value-css-wide
+        - match: '\b(?:symbols|spaces|punctuation|narrow){{b}}'
+          scope: support.constant.property-value.css
+    - include: stray-paren-or-semicolon
+
   # CSS Text Decoration Module Level 3
   property-text-emphasis-style:
     - match: ({{webkit}}\btext-emphasis-style)\s*(:)
@@ -8899,6 +8931,21 @@ contexts:
             )
             {{b}}'
           scope: support.constant.property-value.css
+    - include: stray-paren-or-semicolon
+
+  # CSS Text Decoration Module Level 4
+  property-text-decoration-width:
+    - match: \b(text-decoration-width)\s*(:)
+      captures:
+        1: support.constant.property-name.css
+        2: punctuation.separator.key-value.css
+      push:
+        - meta_content_scope: meta.property-value.text-decoration-width.css
+        - include: end-value
+        - include: value-css-wide
+        - match: '\bauto{{b}}'
+          scope: support.constant.property-value.css
+        - include: length
     - include: stray-paren-or-semicolon
 
   # CSS Text Module Level 3
@@ -9088,6 +9135,21 @@ contexts:
         - include: value-css-wide
         - match: '\b(?:uppercase|none|lowercase|full-width|capitalize){{b}}'
           scope: support.constant.property-value.css
+    - include: stray-paren-or-semicolon
+
+  # CSS Text Decoration Module Level 4
+  property-text-underline-offset:
+    - match: \b(text-underline-offset)\s*(:)
+      captures:
+        1: support.constant.property-name.css
+        2: punctuation.separator.key-value.css
+      push:
+        - meta_content_scope: meta.property-value.text-underline-offset.css
+        - include: end-value
+        - include: value-css-wide
+        - match: '\bauto{{b}}'
+          scope: support.constant.property-value.css
+        - include: length
     - include: stray-paren-or-semicolon
 
   # CSS Text Decoration Module Level 3

--- a/completions/properties.py
+++ b/completions/properties.py
@@ -445,10 +445,13 @@ names = [
     ("text-decoration-color", "text-decoration-color: ${1};"),
     ("text-decoration-line", "text-decoration-line: ${1};"),
     ("text-decoration-skip", "text-decoration-skip: ${1};"),
+    ("text-decoration-skip-ink", "text-decoration-skip-ink: ${1};"),
     ("text-decoration-style", "text-decoration-style: ${1};"),
+    ("text-decoration-width", "text-decoration-width: ${1};"),
     ("text-emphasis", "text-emphasis: ${1};"),
     ("text-emphasis-color", "text-emphasis-color: ${1};"),
     ("text-emphasis-position", "text-emphasis-position: ${1};"),
+    ("text-emphasis-skip", "text-emphasis-skip: ${1};"),
     ("text-emphasis-style", "text-emphasis-style: ${1};"),
     ("text-indent", "text-indent: ${1};"),
     ("text-justify", "text-justify: ${1};"),
@@ -461,6 +464,7 @@ names = [
     ("text-space-trim", "text-space-trim: ${1};"),
     ("text-spacing", "text-spacing: ${1};"),
     ("text-transform", "text-transform: ${1};"),
+    ("text-underline-offset", "text-underline-offset: ${1};"),
     ("text-underline-position", "text-underline-position: ${1};"),
     ("text-wrap", "text-wrap: ${1};"),
     ("top", "top: ${1};"),
@@ -1505,10 +1509,15 @@ name_to_completions = {
     "text-decoration-skip": [
         ("box-decoration",),
         ("edges",),
-        ("ink",),
+        ("leading-spaces",),
         ("none",),
         ("objects",),
         ("spaces",),
+        ("trailing-spaces",),
+    ],
+    "text-decoration-skip-ink": [
+        ("auto",),
+        ("none",),
     ],
     "text-decoration-style": [
         ("dashed",),
@@ -1517,6 +1526,9 @@ name_to_completions = {
         ("solid",),
         ("wavy",),
     ],
+    "text-decoration-width": [
+        ("auto",),
+    ] + t.length,
     "text-emphasis": [
         ("circle",),
         ("dot",),
@@ -1530,6 +1542,12 @@ name_to_completions = {
     ] + t.color,
     "text-emphasis-color": t.color,
     "text-emphasis-position": [("left",), ("over",), ("right",), ("under",)],
+    "text-emphasis-skip": [
+        ("narrow",),
+        ("punctuation",),
+        ("spaces",),
+        ("symbols",),
+    ],
     "text-emphasis-style": [
         ("circle",),
         ("dot",),
@@ -1595,6 +1613,7 @@ name_to_completions = {
         ("none",),
         ("uppercase",),
     ],
+    "text-underline-offset": [("auto",)] + t.length,
     "text-underline-position": [("auto",), ("left",), ("right",), ("under",)],
     "text-wrap": [("balance",), ("normal",), ("nowrap",)],
     "top-right-left-bottom": [


### PR DESCRIPTION
### New Properties in [CSS Text Decoration Module Level 4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-width-property):
```
text-decoration-skip-ink
text-decoration-width
text-emphasis-skip
text-underline-offset
```
### Other Changes
* remove `text-emphasis-skip` from the list of deprecated properties
* remove `ink` as a valid value for `text-emphasis-skip` since it's now a separate property